### PR TITLE
Ranking for on-going season

### DIFF
--- a/ArenaService.Shared/Dtos/RankingSnapshotEntryResponse.cs
+++ b/ArenaService.Shared/Dtos/RankingSnapshotEntryResponse.cs
@@ -1,0 +1,15 @@
+using Libplanet.Crypto;
+
+namespace ArenaService.Shared.Dtos;
+
+public class RankingSnapshotEntryResponse
+{
+    public required Address AgentAddress { get; set; }
+    public required Address AvatarAddress { get; set; }
+    public required string NameWithHash { get; set; }
+    public required int Level { get; set; }
+    public required long Cp { get; set; }
+    public required int Score { get; set; }
+}
+
+

--- a/ArenaService.Shared/Repositories/RankingSnapshotRepository.cs
+++ b/ArenaService.Shared/Repositories/RankingSnapshotRepository.cs
@@ -28,7 +28,9 @@ public interface IRankingSnapshotRepository
 
     Task<List<ArenaService.Shared.Dtos.RankingSnapshotEntryResponse>> GetRankingSnapshotEntries(
         int seasonId,
-        int roundId
+        int roundId,
+        int skip = 0,
+        int take = 1000
     );
 }
 
@@ -111,7 +113,9 @@ public class RankingSnapshotRepository : IRankingSnapshotRepository
 
     public async Task<List<ArenaService.Shared.Dtos.RankingSnapshotEntryResponse>> GetRankingSnapshotEntries(
         int seasonId,
-        int roundId
+        int roundId,
+        int skip = 0,
+        int take = 1000
     )
     {
         var query =
@@ -129,6 +133,6 @@ public class RankingSnapshotRepository : IRankingSnapshotRepository
                 Score = snapshot.Score
             };
 
-        return await query.ToListAsync();
+        return await query.Skip(skip).Take(take).ToListAsync();
     }
 }

--- a/ArenaService/Controllers/LeaderboardController.cs
+++ b/ArenaService/Controllers/LeaderboardController.cs
@@ -55,10 +55,17 @@ public class LeaderboardController : ControllerBase
     )]
     public async Task<ActionResult<List<ArenaService.Shared.Dtos.RankingSnapshotEntryResponse>>> GetRankingSnapshot(
         [FromQuery] int seasonId,
-        [FromQuery] int roundId
+        [FromQuery] int roundId,
+        [FromQuery] int skip = 0,
+        [FromQuery] int take = 1000
     )
     {
-        var entries = await _rankingSnapshotRepo.GetRankingSnapshotEntries(seasonId, roundId);
+        // Limit the maximum page size to 1000
+        if (take > 1000)
+        {
+            take = 1000;
+        }
+        var entries = await _rankingSnapshotRepo.GetRankingSnapshotEntries(seasonId, roundId, skip, take);
         return Ok(entries);
     }
 

--- a/ArenaService/Controllers/LeaderboardController.cs
+++ b/ArenaService/Controllers/LeaderboardController.cs
@@ -17,6 +17,7 @@ public class LeaderboardController : ControllerBase
     private readonly ISeasonService _seasonService;
     private readonly ISeasonRepository _seasonRepo;
     private readonly ISeasonCacheRepository _seasonCacheRepo;
+    private readonly IRankingSnapshotRepository _rankingSnapshotRepo;
 
     public LeaderboardController(
         IAllClanRankingRepository allClanRankingRepo,
@@ -24,7 +25,8 @@ public class LeaderboardController : ControllerBase
         ILeaderboardRepository leaderboardRepo,
         ISeasonService seasonService,
         ISeasonCacheRepository seasonCacheRepo,
-        ISeasonRepository seasonRepo
+        ISeasonRepository seasonRepo,
+        IRankingSnapshotRepository rankingSnapshotRepo
     )
     {
         _allClanRankingRepo = allClanRankingRepo;
@@ -33,6 +35,7 @@ public class LeaderboardController : ControllerBase
         _seasonService = seasonService;
         _seasonCacheRepo = seasonCacheRepo;
         _seasonRepo = seasonRepo;
+        _rankingSnapshotRepo = rankingSnapshotRepo;
     }
 
     [HttpGet("count")]
@@ -42,6 +45,21 @@ public class LeaderboardController : ControllerBase
         var rankingCount = await _rankingRepo.GetRankingCountAsync(seasonId, roundIndex);
 
         return Ok(rankingCount);
+    }
+
+    [HttpGet("participants")]
+    [SwaggerResponse(
+        StatusCodes.Status200OK,
+        "Ranking ongoing participants",
+        typeof(List<ArenaService.Shared.Dtos.RankingSnapshotEntryResponse>)
+    )]
+    public async Task<ActionResult<List<ArenaService.Shared.Dtos.RankingSnapshotEntryResponse>>> GetRankingSnapshot(
+        [FromQuery] int seasonId,
+        [FromQuery] int roundId
+    )
+    {
+        var entries = await _rankingSnapshotRepo.GetRankingSnapshotEntries(seasonId, roundId);
+        return Ok(entries);
     }
 
     [HttpGet("completed")]


### PR DESCRIPTION
While there is an endpoint for rankings for when the season ends.

There has been a very big demand from the community to be able to get ranking from the on-going season.
As targets are selected randomly, there shouldn't be any downsides of making the on-going rankings public.

This pull request would allow someone to pull the on-going rankings, or observe previous rounds rankings by using:
http://localhost:5025/leaderboard/participants?seasonId=23&roundId=38

Which would return a sample result of:

> `[
>   {
>     "agentAddress": "cf1270e34b683fb42c9c4339e2a72c3d474f8db4",
>     "avatarAddress": "cf1270e34b683fb42c9c4339e2a72c3d474f8db4",
>     "nameWithHash": "Triplexmazi <size=80%><color=#A68F7E>#cf12</color></size>",
>     "level": 415,
>     "cp": 90566268,
>     "score": 1001
>   },
>   {
>     "agentAddress": "d9186d0a270b8ac77407602e198c6bb21db0ac4e",
>     "avatarAddress": "d9186d0a270b8ac77407602e198c6bb21db0ac4e",
>     "nameWithHash": "Satan <size=80%><color=#A68F7E>#d918</color></size>",
>     "level": 414,
>     "cp": 101383775,
>     "score": 1000
>   },
>   {
>     "agentAddress": "f9cd29951b3addce2a926955ef22a846fd8b1d06",
>     "avatarAddress": "f9cd29951b3addce2a926955ef22a846fd8b1d06",
>     "nameWithHash": "Harem <size=80%><color=#A68F7E>#f9CD</color></size>",
>     "level": 413,
>     "cp": 49502374,
>     "score": 1000
>   },
>   {
>     "agentAddress": "a9843fa08fe952d74b602c29bcab08e2ad7664d3",
>     "avatarAddress": "a9843fa08fe952d74b602c29bcab08e2ad7664d3",
>     "nameWithHash": "Deus <size=80%><color=#A68F7E>#a984</color></size>",
>     "level": 406,
>     "cp": 25282464,
>     "score": 1000
>   }
>   ]`