### PR TITLE
Add BattleTxTracker cache deletion and backoffice navbar display

### DIFF
--- a/ArenaService.BackOffice/Components/Shared/BlockTrackerStatus.razor
+++ b/ArenaService.BackOffice/Components/Shared/BlockTrackerStatus.razor
@@ -1,0 +1,44 @@
+@using ArenaService.Shared.Repositories
+@inject IBlockTrackerRepository BlockTrackerRepo
+@implements IAsyncDisposable
+
+<span class="text-muted small">
+    Battle Tracker: <strong>@(_blockIndex >= 0 ? _blockIndex.ToString("N0") : "-")</strong>
+</span>
+
+@code {
+    private long _blockIndex = -1;
+    private PeriodicTimer? _timer;
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        _blockIndex = await BlockTrackerRepo.GetBattleTxTrackerBlockIndexAsync();
+        _timer = new PeriodicTimer(TimeSpan.FromSeconds(8));
+        _ = RefreshLoop();
+    }
+
+    private async Task RefreshLoop()
+    {
+        try
+        {
+            while (_timer is not null && await _timer.WaitForNextTickAsync(_cts.Token))
+            {
+                var newIndex = await BlockTrackerRepo.GetBattleTxTrackerBlockIndexAsync();
+                if (newIndex != _blockIndex)
+                {
+                    _blockIndex = newIndex;
+                    await InvokeAsync(StateHasChanged);
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _cts.Cancel();
+        _timer?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/ArenaService.BackOffice/Components/Shared/MainLayout.razor
+++ b/ArenaService.BackOffice/Components/Shared/MainLayout.razor
@@ -8,7 +8,8 @@
 
     <main>
         <div class="top-row px-4">
-            <div class="d-flex justify-content-end w-100">
+            <div class="d-flex justify-content-between w-100 align-items-center">
+                <BlockTrackerStatus />
                 <div class="d-flex align-items-center gap-3">
                     <AuthorizeView>
                         <Authorized>

--- a/ArenaService.BackOffice/Program.cs
+++ b/ArenaService.BackOffice/Program.cs
@@ -112,6 +112,7 @@ builder.Services.AddSingleton<IConnectionMultiplexer>(provider =>
 });
 
 builder.Services.AddScoped<ISeasonCacheRepository, SeasonCacheRepository>();
+builder.Services.AddScoped<IBlockTrackerRepository, BlockTrackerRepository>();
 builder.Services.AddScoped<IBattleTicketPolicyRepository, BattleTicketPolicyRepository>();
 builder.Services.AddScoped<IRefreshTicketPolicyRepository, RefreshTicketPolicyRepository>();
 builder.Services.AddScoped<ISeasonRepository, SeasonRepository>();

--- a/ArenaService.Shared/Repositories/BlockTrackerRepository.cs
+++ b/ArenaService.Shared/Repositories/BlockTrackerRepository.cs
@@ -6,6 +6,7 @@ public interface IBlockTrackerRepository
 {
     Task<long> GetBattleTxTrackerBlockIndexAsync();
     Task SetBattleTxTrackerBlockIndexAsync(long blockIndex);
+    Task DeleteBattleTxTrackerBlockIndexAsync();
 }
 
 public class BlockTrackerRepository : IBlockTrackerRepository
@@ -28,5 +29,10 @@ public class BlockTrackerRepository : IBlockTrackerRepository
     public async Task SetBattleTxTrackerBlockIndexAsync(long blockIndex)
     {
         await _redis.StringSetAsync($"{PREFIX}:{BATTLE_TX_TRACKER_KEY}", blockIndex);
+    }
+
+    public async Task DeleteBattleTxTrackerBlockIndexAsync()
+    {
+        await _redis.KeyDeleteAsync($"{PREFIX}:{BATTLE_TX_TRACKER_KEY}");
     }
 } 

--- a/ArenaService.Shared/Services/CacheInitializationService.cs
+++ b/ArenaService.Shared/Services/CacheInitializationService.cs
@@ -43,9 +43,11 @@ public class CacheInitializationService : ICacheInitializationService
             return false;
         }
 
-        await _rankingRepository.ClearAllRankingCacheAsync();
-        await _seasonCacheRepository.DeleteAllAsync();
-        await _blockTrackerRepository.DeleteBattleTxTrackerBlockIndexAsync();
+        await Task.WhenAll(
+            _rankingRepository.ClearAllRankingCacheAsync(),
+            _seasonCacheRepository.DeleteAllAsync(),
+            _blockTrackerRepository.DeleteBattleTxTrackerBlockIndexAsync()
+        );
         return true;
     }
 }

--- a/ArenaService.Shared/Services/CacheInitializationService.cs
+++ b/ArenaService.Shared/Services/CacheInitializationService.cs
@@ -13,18 +13,21 @@ public class CacheInitializationService : ICacheInitializationService
     private readonly IRankingSnapshotRepository _rankingSnapshotRepository;
     private readonly IParticipantRepository _participantRepository;
     private readonly ISeasonCacheRepository _seasonCacheRepository;
+    private readonly IBlockTrackerRepository _blockTrackerRepository;
 
     public CacheInitializationService(
         IRankingRepository rankingRepository,
         IRankingSnapshotRepository rankingSnapshotRepository,
         IParticipantRepository participantRepository,
-        ISeasonCacheRepository seasonCacheRepository
+        ISeasonCacheRepository seasonCacheRepository,
+        IBlockTrackerRepository blockTrackerRepository
     )
     {
         _rankingRepository = rankingRepository;
         _rankingSnapshotRepository = rankingSnapshotRepository;
         _participantRepository = participantRepository;
         _seasonCacheRepository = seasonCacheRepository;
+        _blockTrackerRepository = blockTrackerRepository;
     }
 
     public async Task<bool> InitializeRankingCacheAsync(int seasonId, int roundId)
@@ -42,6 +45,7 @@ public class CacheInitializationService : ICacheInitializationService
 
         await _rankingRepository.ClearAllRankingCacheAsync();
         await _seasonCacheRepository.DeleteAllAsync();
+        await _blockTrackerRepository.DeleteBattleTxTrackerBlockIndexAsync();
         return true;
     }
 }

--- a/ArenaService.Tests/Services/CacheInitializationServiceTests.cs
+++ b/ArenaService.Tests/Services/CacheInitializationServiceTests.cs
@@ -1,0 +1,94 @@
+namespace ArenaService.Tests.Services;
+
+using ArenaService.Shared.Models;
+using ArenaService.Shared.Repositories;
+using ArenaService.Shared.Services;
+using Moq;
+using Xunit;
+
+public class CacheInitializationServiceTests
+{
+    private readonly Mock<IRankingRepository> _rankingRepoMock;
+    private readonly Mock<IRankingSnapshotRepository> _rankingSnapshotRepoMock;
+    private readonly Mock<IParticipantRepository> _participantRepoMock;
+    private readonly Mock<ISeasonCacheRepository> _seasonCacheRepoMock;
+    private readonly Mock<IBlockTrackerRepository> _blockTrackerRepoMock;
+    private readonly ICacheInitializationService _service;
+
+    public CacheInitializationServiceTests()
+    {
+        _rankingRepoMock = new Mock<IRankingRepository>();
+        _rankingSnapshotRepoMock = new Mock<IRankingSnapshotRepository>();
+        _participantRepoMock = new Mock<IParticipantRepository>();
+        _seasonCacheRepoMock = new Mock<ISeasonCacheRepository>();
+        _blockTrackerRepoMock = new Mock<IBlockTrackerRepository>();
+        _service = new CacheInitializationService(
+            _rankingRepoMock.Object,
+            _rankingSnapshotRepoMock.Object,
+            _participantRepoMock.Object,
+            _seasonCacheRepoMock.Object,
+            _blockTrackerRepoMock.Object
+        );
+    }
+
+    [Fact]
+    public async Task InitializeRankingCacheAsync_WhenSnapshotCountSufficient_ShouldDeleteAllCachesAndReturnTrue()
+    {
+        // Arrange
+        const int seasonId = 1;
+        const int roundId = 1;
+        const int participantCount = 100;
+        const int snapshotCount = 60; // >= participantCount - 50 (50)
+
+        _rankingSnapshotRepoMock
+            .Setup(x => x.GetRankingSnapshotsCount(seasonId, roundId, It.IsAny<Func<IQueryable<RankingSnapshot>, IQueryable<RankingSnapshot>>?>()))
+            .ReturnsAsync(snapshotCount);
+        _participantRepoMock
+            .Setup(x => x.GetParticipantCountAsync(seasonId))
+            .ReturnsAsync(participantCount);
+        _rankingRepoMock
+            .Setup(x => x.ClearAllRankingCacheAsync())
+            .Returns(Task.CompletedTask);
+        _seasonCacheRepoMock
+            .Setup(x => x.DeleteAllAsync())
+            .Returns(Task.CompletedTask);
+        _blockTrackerRepoMock
+            .Setup(x => x.DeleteBattleTxTrackerBlockIndexAsync())
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.InitializeRankingCacheAsync(seasonId, roundId);
+
+        // Assert
+        Assert.True(result);
+        _rankingRepoMock.Verify(x => x.ClearAllRankingCacheAsync(), Times.Once);
+        _seasonCacheRepoMock.Verify(x => x.DeleteAllAsync(), Times.Once);
+        _blockTrackerRepoMock.Verify(x => x.DeleteBattleTxTrackerBlockIndexAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task InitializeRankingCacheAsync_WhenSnapshotCountInsufficient_ShouldNotDeleteCachesAndReturnFalse()
+    {
+        // Arrange
+        const int seasonId = 1;
+        const int roundId = 1;
+        const int participantCount = 100;
+        const int snapshotCount = 40; // < participantCount - 50 (50)
+
+        _rankingSnapshotRepoMock
+            .Setup(x => x.GetRankingSnapshotsCount(seasonId, roundId, It.IsAny<Func<IQueryable<RankingSnapshot>, IQueryable<RankingSnapshot>>?>()))
+            .ReturnsAsync(snapshotCount);
+        _participantRepoMock
+            .Setup(x => x.GetParticipantCountAsync(seasonId))
+            .ReturnsAsync(participantCount);
+
+        // Act
+        var result = await _service.InitializeRankingCacheAsync(seasonId, roundId);
+
+        // Assert
+        Assert.False(result);
+        _rankingRepoMock.Verify(x => x.ClearAllRankingCacheAsync(), Times.Never);
+        _seasonCacheRepoMock.Verify(x => x.DeleteAllAsync(), Times.Never);
+        _blockTrackerRepoMock.Verify(x => x.DeleteBattleTxTrackerBlockIndexAsync(), Times.Never);
+    }
+}


### PR DESCRIPTION
## Summary

- 캐시 초기화 시 BattleTxTracker Redis 캐시(`block_tracker:battle_tx_tracker:last_processed_block`)도 함께 삭제되도록 추가
- 백오피스 상단 바에 BattleTxTracker 현재 추적 블록 높이를 8초마다 자동 갱신하여 표시
- `IBlockTrackerRepository`에 `DeleteBattleTxTrackerBlockIndexAsync()` 메서드 추가
- 캐시 삭제 3개를 `Task.WhenAll`로 병렬 실행하여 초기화 속도 개선
- `CacheInitializationService` 유닛 테스트 추가

## Test plan

- [ ] 백오피스 상단 바에 "Battle Tracker: N" 형태로 블록 높이 표시 확인
- [ ] 8초마다 값이 자동 갱신되는지 확인
- [ ] Cache Initialization 페이지에서 캐시 초기화 후 Redis에서 `block_tracker:battle_tx_tracker:last_processed_block` 키 삭제 확인
- [ ] `dotnet test` 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)